### PR TITLE
Correções upload de arquivos/ alocação de docentes (Coordenador/Facilitador)

### DIFF
--- a/src/src/Controller/ClazzesController.php
+++ b/src/src/Controller/ClazzesController.php
@@ -81,17 +81,6 @@ class ClazzesController extends AppController
         $this->set('teachers', $this->Clazzes->ClazzesTeachers->Teachers->find('list')->contain(['Users'])->toArray());
         $this->set('schedules', $this->Clazzes->ClazzesSchedulesLocals->find('list')->contain(['Schedules', 'Locals'])->toArray());
 
-		$files = array();
-		$clazzes_arr = $this->paginate($clazzes)->toArray();
-		foreach($clazzes_arr as $clazz) {
-			$dir = new Folder(WWW_ROOT.'/finishedClazzes/clazz-' . $clazz->id);
-			if ($dir) {
-				$dir_files = $dir->find(); 
-				$files[$clazz->id] = $dir_files;
-			}
-		}
-		
-		$this->set('files', $files);
         $this->set('clazzes', $this->paginate($clazzes));
         $this->set('_serialize', ['clazzes']);
     }

--- a/src/src/Controller/ClazzesController.php
+++ b/src/src/Controller/ClazzesController.php
@@ -6,7 +6,6 @@ use Cake\Filesystem\Folder;
 use Cake\Filesystem\File;
 use Cake\ORM\Query;
 
-
 /**
  * Clazzes Controller
  *
@@ -82,6 +81,17 @@ class ClazzesController extends AppController
         $this->set('teachers', $this->Clazzes->ClazzesTeachers->Teachers->find('list')->contain(['Users'])->toArray());
         $this->set('schedules', $this->Clazzes->ClazzesSchedulesLocals->find('list')->contain(['Schedules', 'Locals'])->toArray());
 
+		$files = array();
+		$clazzes_arr = $this->paginate($clazzes)->toArray();
+		foreach($clazzes_arr as $clazz) {
+			$dir = new Folder(WWW_ROOT.'/finishedClazzes/clazz-' . $clazz->id);
+			if ($dir) {
+				$dir_files = $dir->find(); 
+				$files[$clazz->id] = $dir_files;
+			}
+		}
+		
+		$this->set('files', $files);
         $this->set('clazzes', $this->paginate($clazzes));
         $this->set('_serialize', ['clazzes']);
     }
@@ -638,8 +648,8 @@ class ClazzesController extends AppController
             'contain' => []
         ]);
 		
-		$clazzes_dir = $this->checkDirectory(WWW_ROOT.'/finishedClazzes');
-		$dir = $this->checkDirectory(WWW_ROOT.'/finishedClazzes/clazz-' . $id);
+		$clazzes_dir = $this->Clazzes->checkDirectory(WWW_ROOT.'/finishedClazzes');
+		$dir = $this->Clazzes->checkDirectory(WWW_ROOT.'/finishedClazzes/clazz-' . $id);
 		
 		$files = $dir->find();
 		
@@ -654,7 +664,7 @@ class ClazzesController extends AppController
 			$invalidNames = false;
 			
 			foreach ($data as $file) {
-				if (!$this->checkName($file['name'])) {
+				if (!$this->Clazzes->checkName($file['name'])) {
 					$this->Flash->error(__('Um ou mais nomes de arquivos são inválidos. Verifique e tente novamente. ' . 
 							'(Nome inválido: ' . $file['name'] .  ')'));
 					$invalidNames = true;
@@ -686,33 +696,5 @@ class ClazzesController extends AppController
         $this->set('clazze', $clazze);
         $this->set('_serialize', ['clazze']);
 	}
-	
-	/**
-	 * Check if the file name is valid.
-	 * @access public
-	 * @param String $fileName
-	 * @return if the image is valid
-	*/ 
-	private function checkName($fileName)
-	{
-		return (bool) ((preg_match("`^[-0-9A-Z_\.\\s]+$`i",$fileName) && mb_strlen($fileName,"UTF-8") < 225) ? true : false);
-	}
 
-	
-	/**
-	 * Check if the directory exists. If not, then the system will create it.
-	 * @access public
-	 * @param String $dir
-	 * @return the selected folder
-	*/ 
-	private function checkDirectory($dir)
-	{
-		if (!is_dir($dir)){
-			$folder = new Folder();
-			$folder->create($dir);
-			return $folder;
-		} else {
-			return new Folder($dir);
-		}
-	}
 }

--- a/src/src/Controller/TeachersController.php
+++ b/src/src/Controller/TeachersController.php
@@ -13,32 +13,13 @@ use Cake\View\Helper\SessionHelper;
  */
 class TeachersController extends AppController
 {
-	private $_userRoles;
-
-	public function initialize()
-    {
-        parent::initialize();
-		
-		$roles = array();
-		if ($this->loggedUser) {
-			foreach ($this->loggedUser->teacher->roles as $r) {
-				$roles[] = $r->type;
-			}
-		}
-		
-		$this->_userRoles = $roles;
-			
-    }
-
 	public function isAuthorized($user)
 	{
-		return true; //remove line on production
-
 		//Only admin or teacher itself can edit the teacher
 		if (in_array($this->request->action, ['edit', 'allocateClazzes'])) {
 			$teacherId = (int)$this->request->params['pass'][0];
 
-			if ($user['id'] === $teacherId || $user['is_admin'] || in_array('COORDINATOR', $this->_userRoles)) {
+			if ($this->loggedUser->teacher->id === $teacherId || $this->loggedUser->canAdmin()) {
 				return true;
 			}
 
@@ -58,7 +39,7 @@ class TeachersController extends AppController
 
 		$this->set('teachers', $this->paginate($this->Teachers->find('all')->contain(['Users'])));
 
-		if (!in_array('COORDINATOR', $this->_userRoles)) {
+		if (!$this->loggedUser->isCoordinator()) {
 
 			$this->set('teachers', $this->paginate($this->Teachers->find('all')
 				->contain(['Users' ])

--- a/src/src/Controller/UsersController.php
+++ b/src/src/Controller/UsersController.php
@@ -12,6 +12,18 @@ use Cake\Event\Event;
  */
 class UsersController extends AppController
 {
+	
+	public function isAuthorized($user)
+	{
+		//Must be logged as teacher
+		if (in_array($this->request->action, ['myAccount'])) {
+			if(isset($this->loggedUser->teacher) && $this->loggedUser->teacher != null) {
+                return True;
+            }
+		}
+
+		return parent::isAuthorized($user);
+	}
 
     public function beforeFilter(Event $event)
     {
@@ -171,5 +183,16 @@ class UsersController extends AppController
             $this->Flash->error(__('Não foi possível remover o usuário, tente novamente.'));
         }
         return $this->redirect(['action' => 'index']);
+    }
+	
+	/**
+     * My Account method
+     *
+     * @param string|null $id User id.
+     * @return \Cake\Network\Response|null Redirects to Teachers/edit/<teacher_id>.
+     */
+    public function myAccount()
+    {	
+        return $this->redirect(['controller' => 'Teachers', 'action' => 'edit', $this->loggedUser->teacher->id]);
     }
 }

--- a/src/src/Model/Entity/Clazze.php
+++ b/src/src/Model/Entity/Clazze.php
@@ -5,6 +5,7 @@ use Cake\ORM\Entity;
 use Cake\ORM\TableRegistry;
 use Cake\View\Helper\HtmlHelper;
 use Cake\View\View;
+use Cake\Filesystem\Folder;
 
 /**
  * Clazze Entity.
@@ -158,5 +159,16 @@ class Clazze extends Entity
         }
 
         return $display;
+    }
+	
+	public function _getFiles()
+    {
+        $files = array();
+		$dir = new Folder(WWW_ROOT.'/finishedClazzes/clazz-' . $this->id);
+		if ($dir) {
+			$files = $dir->find();
+		}
+		
+		return $files;
     }
 }

--- a/src/src/Model/Entity/Clazze.php
+++ b/src/src/Model/Entity/Clazze.php
@@ -161,6 +161,16 @@ class Clazze extends Entity
         return $display;
     }
 	
+	public function _getSelectedTeachersIds() {
+		$ids = array();
+        if(!empty($this->selectedTeachers)) {
+            foreach($this->selectedTeachers as $teacher) {
+                $ids[] = $teacher->id;
+            }
+        }
+        return $ids;
+    }
+	
 	public function _getFiles()
     {
         $files = array();

--- a/src/src/Model/Table/ClazzesTable.php
+++ b/src/src/Model/Table/ClazzesTable.php
@@ -8,6 +8,8 @@ use Cake\ORM\Rule\IsUnique;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
+use Cake\Filesystem\Folder;
+use Cake\Filesystem\File;
 
 /**
  * Clazzes Model
@@ -300,5 +302,34 @@ class ClazzesTable extends Table
 				}
 			])
 			->hydrate(false)->toArray();
+	}
+	
+	/**
+	 * Check if the file name is valid.
+	 * @access public
+	 * @param String $fileName
+	 * @return if the image is valid
+	*/ 
+	public function checkName($fileName)
+	{
+		return (bool) ((preg_match("`^[-0-9A-Z_\.\\s]+$`i",$fileName) && mb_strlen($fileName,"UTF-8") < 225) ? true : false);
+	}
+
+	
+	/**
+	 * Check if the directory exists. If not, then the system will create it.
+	 * @access public
+	 * @param String $dir
+	 * @return the selected folder
+	*/ 
+	public function checkDirectory($dir)
+	{
+		if (!is_dir($dir)){
+			$folder = new Folder();
+			$folder->create($dir);
+			return $folder;
+		} else {
+			return new Folder($dir);
+		}
 	}
 }

--- a/src/src/Model/Table/RolesTable.php
+++ b/src/src/Model/Table/RolesTable.php
@@ -64,7 +64,7 @@ class RolesTable extends Table
                         $roles = $this->find('all', [
                             'conditions' => ['type' => 'COORDINATOR', 'teacher_id' => $context['data']['teacher_id']]
                         ]);
-                        if ($roles && count($roles) > 0) {
+                        if ($roles && count($roles->toArray()) > 0) {
                             return false;
                         }
                     }

--- a/src/src/Template/Clazzes/allocate_teacher.ctp
+++ b/src/src/Template/Clazzes/allocate_teacher.ctp
@@ -133,9 +133,9 @@
 									</tr>
 								<?php endif; ?>
 								<?php foreach ($teachers as $teacher): ?>
-									<tr id="<?php echo $teacher->id; ?>">
+									<tr style="<?php echo ($teacher->id == $recomendedTeacher) ? 'background-color:lightblue;' : ''; ?>">
 										<td><?= h($teacher->id) ?></td>
-										<td><?= h($teacher->user->name) ?></td>
+										<td><?= h(($teacher->id == $recomendedTeacher) ? $teacher->user->name . ' (Recomendado)' : $teacher->user->name) ?></td>
 										<td><?= h($teacher->registry) ?></td>
 										<td><?= h($teacher->workload) ?></td>
 										<td><?= h($teacher->formation) ?></td>

--- a/src/src/Template/Clazzes/index.ctp
+++ b/src/src/Template/Clazzes/index.ctp
@@ -1,4 +1,3 @@
-<?php use Cake\Filesystem\Folder; ?>
 <?php $this->assign('title', 'Turmas'); ?>
 <?php $this->start('breadcrumb'); ?>
 <li><?= $this->Html->link('<i class="fa fa-dashboard"></i>' . __('Dashboard'), '/', ['escape' => false]) ?></li>
@@ -102,13 +101,6 @@
                         </tr>
                     <?php else: ?>
                         <?php foreach ($clazzes as $clazz): ?>
-							<?php 
-								$files = array();
-								$dir = new Folder(WWW_ROOT.'/finishedClazzes/clazz-' . $clazz->id);
-								if ($dir) {
-									$files = $dir->find(); 
-								}
-							?>
                             <tr>
                                 <td><?= $this->Number->format($clazz->id) ?></td>
                                 <td><?= $this->Html->link($clazz->process->name, ['controller' => 'Processes', 'action' => 'view', $clazz->process->id]) ?></td>
@@ -136,15 +128,15 @@
                                         '',
                                         ['action' => 'finishClazze', $clazz->id],
                                         [
-                                            'title' => (count($files) == 3) ? 
+                                            'title' => (count($files[$clazz->id]) == 3) ? 
 												__('Finalizar Turma (Já existem arquivos enviados)') : 
-												((count($files) > 0 && count($files) < 3) ? __('Finalizar Turma (Arquivos incompletos)') : __('Finalizar Turma')),
-                                            'class' => (count($files) == 3) ? 'btn btn-sm btn-default glyphicon glyphicon-folder-close' 
+												((count($files[$clazz->id]) > 0 && count($files[$clazz->id]) < 3) ? __('Finalizar Turma (Arquivos incompletos)') : __('Finalizar Turma')),
+                                            'class' => (count($files[$clazz->id]) == 3) ? 'btn btn-sm btn-default glyphicon glyphicon-folder-close' 
 														: 'btn btn-sm btn-default glyphicon glyphicon-folder-open',
                                             'data-toggle' => 'tooltip',
-                                            'data-original-title' => (count($files) == 3) ? 
+                                            'data-original-title' => (count($files[$clazz->id]) == 3) ? 
 												__('Finalizar Turma (Já existem arquivos enviados)') : 
-												((count($files) > 0 && count($files) < 3) ? __('Finalizar Turma (Arquivos incompletos)') : __('Finalizar Turma')),
+												((count($files[$clazz->id]) > 0 && count($files[$clazz->id]) < 3) ? __('Finalizar Turma (Arquivos incompletos)') : __('Finalizar Turma')),
                                         ]
                                     ) ?>
 									<?php endif; ?>

--- a/src/src/Template/Clazzes/index.ctp
+++ b/src/src/Template/Clazzes/index.ctp
@@ -163,6 +163,18 @@
                                         ]
                                     ) ?>
                                     <?php endif; ?>
+									<?php if($loggedUser !== false && ($loggedUser->canAdmin() || $loggedUser->isFacilitatorOf($clazz->subject->knowledge_id))): ?>
+									<?= $this->Html->link(
+										'',
+										['controller' => 'Clazzes', 'action' => 'allocateTeacher', $clazz->id],
+										[
+											'title' => __('Alocar Docente'),
+											'class' => 'btn btn-sm btn-primary glyphicon glyphicon-education',
+											'data-toggle' => 'tooltip',
+											'data-original-title' => __('Alocar docente para ministrar a Turma'),
+										]
+									) ?>
+									<?php endif; ?>
                                 </td>
                             </tr>
 

--- a/src/src/Template/Clazzes/index.ctp
+++ b/src/src/Template/Clazzes/index.ctp
@@ -123,7 +123,7 @@
                                     <button data-clazz-id="<?= $clazz->id ?>" class="btn btn-sm btn-info fa fa-glyph fa-calendar-plus-o"
                                             title ="<?= __('Locais/horários de aula') ?>"
                                             data-toggle="tooltip" data-original-title="<?= __('Locais/horários de aula') ?>"></button>
-									<?php if(count($clazz->selectedTeachers) > 0): ?>
+									<?php if(count($clazz->selectedTeachers) > 0 && in_array($loggedUser->teacher->id, $clazz->selectedTeachersIds)): ?>
 									<?= $this->Html->link(
                                         '',
                                         ['action' => 'finishClazze', $clazz->id],

--- a/src/src/Template/Clazzes/index.ctp
+++ b/src/src/Template/Clazzes/index.ctp
@@ -128,15 +128,15 @@
                                         '',
                                         ['action' => 'finishClazze', $clazz->id],
                                         [
-                                            'title' => (count($files[$clazz->id]) == 3) ? 
+                                            'title' => (count($clazz->files) == 3) ? 
 												__('Finalizar Turma (Já existem arquivos enviados)') : 
-												((count($files[$clazz->id]) > 0 && count($files[$clazz->id]) < 3) ? __('Finalizar Turma (Arquivos incompletos)') : __('Finalizar Turma')),
-                                            'class' => (count($files[$clazz->id]) == 3) ? 'btn btn-sm btn-default glyphicon glyphicon-folder-close' 
+												((count($clazz->files) > 0 && count($clazz->files) < 3) ? __('Finalizar Turma (Arquivos incompletos)') : __('Finalizar Turma')),
+                                            'class' => (count($clazz->files) == 3) ? 'btn btn-sm btn-default glyphicon glyphicon-folder-close' 
 														: 'btn btn-sm btn-default glyphicon glyphicon-folder-open',
                                             'data-toggle' => 'tooltip',
-                                            'data-original-title' => (count($files[$clazz->id]) == 3) ? 
+                                            'data-original-title' => (count($clazz->files) == 3) ? 
 												__('Finalizar Turma (Já existem arquivos enviados)') : 
-												((count($files[$clazz->id]) > 0 && count($files[$clazz->id]) < 3) ? __('Finalizar Turma (Arquivos incompletos)') : __('Finalizar Turma')),
+												((count($clazz->files) > 0 && count($clazz->files) < 3) ? __('Finalizar Turma (Arquivos incompletos)') : __('Finalizar Turma')),
                                         ]
                                     ) ?>
 									<?php endif; ?>

--- a/src/src/Template/Element/user-nav-menu.ctp
+++ b/src/src/Template/Element/user-nav-menu.ctp
@@ -64,7 +64,7 @@
                 </li>
                 <li class="user-footer">
                     <div class="pull-left">
-                        <?= $this->Html->link(__('Minha conta'), ['controller' => 'users', 'action' => 'my_account'], ['class' => 'btn btn-default btn-flat']) ?>
+                        <?= $this->Html->link(__('Minha conta'), ['controller' => 'users', 'action' => 'myAccount'], ['class' => 'btn btn-default btn-flat']) ?>
                     </div>
                     <div class="pull-right">
                         <?= $this->Html->link(__('Sair'), ['controller' => 'users', 'action' => 'logout'], ['class' => 'btn btn-default btn-flat']) ?>

--- a/src/src/Template/Processes/index.ctp
+++ b/src/src/Template/Processes/index.ctp
@@ -60,6 +60,7 @@
                                             'data-original-title' => __('Visualizar'),
                                         ]
                                     ) ?>
+									<?php if($loggedUser !== false && $loggedUser->canAdmin()): ?>
                                     <?php if($process->status == 'OPENED' ): ?>
                                         <?= $this->Html->link(
                                             '',
@@ -106,6 +107,7 @@
                                                 'data-original-title' => __('Clonar Processo'),
                                             ]
                                         ) ?>
+									<?php endif; ?>
 									<?php endif; ?>
                                 </td>
                             </tr>

--- a/src/src/Template/Teachers/add.ctp
+++ b/src/src/Template/Teachers/add.ctp
@@ -49,7 +49,8 @@
                                     ['value' => '1', 'text' => 'Sim'],
                                     ['value' => '0', 'text' => 'Não'],
 
-                                ], ['hiddenField' => false, 'label' => 'É Administrador', 'disabled' => true]);
+                                ], ['hiddenField' => false, 'label' => 'É Administrador', 
+									'disabled' => (($loggedUser !== false && $loggedUser->canAdmin()) ? false : true)]);
                             ?>
                             </label>
                         </fieldset>

--- a/src/src/Template/Teachers/edit.ctp
+++ b/src/src/Template/Teachers/edit.ctp
@@ -13,11 +13,11 @@
                 <h3 class="box-title">Editar docente #<?= $teacher->id ?></h3>
 				<div class="pull-right box-tools">
 					<?= $this->Html->link(
-						'',
+						'Escolher Turmas de Interesse',
 						['action' => 'allocateClazzes', $teacher->id],
 						[
 							'title' => __('Turmas de Interesse'),
-							'class' => 'btn btn-sm btn-default glyphicon glyphicon-education',
+							'class' => 'btn btn-sm btn-primary',
 							'data-toggle' => 'tooltip',
 							'data-original-title' => __('Escolher turmas de interesse para concorrer em Processo de Distribuição'),
 						]
@@ -67,7 +67,8 @@
 									['value' => '1', 'text' => 'Sim'],
 									['value' => '0', 'text' => 'Não'],
 
-								], ['hiddenField' => false, 'label' => 'É Administrador', 'disabled' => true]);
+								], ['hiddenField' => false, 'label' => 'É Administrador', 
+									'disabled' => (($loggedUser !== false && $loggedUser->canAdmin()) ? false : true)]);
 							?>
 							</label>
 						</fieldset>


### PR DESCRIPTION
- Criação de Ação na tela de turmas para alocação pelo coordenador/facilitador;
- Somente coordenador ou facilitador do núcleo tem acesso ao botão de alocação de docentes;
- Mostrando docente recomendado;
- Correção erro na hora de atribuir papel de coordenador;
- Somente próprio professor pode fazer upload de arquivos da turma.
- Criação método myAccount();
- Correções em permissões da tela de Docentes.
